### PR TITLE
Add the "types" package.json property

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lib",
     "types/*.d.ts"
   ],
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/bytegem/vue-heroicons.git"


### PR DESCRIPTION
This will help IDEs find the types automatically without requiring user intervention